### PR TITLE
feat: add transaction command for Safe transaction pool integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vito-contracts"]
+	path = vito-contracts
+	url = git@github.com:hadv/vito-contracts.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
+tokio = { version = "1.36", features = ["full"] }
+ethers = { version = "2.0", features = ["legacy"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+lazy_static = "1.4"
+hex = "0.4"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod tx; 

--- a/src/commands/tx.rs
+++ b/src/commands/tx.rs
@@ -1,0 +1,218 @@
+use anyhow::{Result, Context, bail};
+use std::str::FromStr;
+use ethers::{
+    providers::{Provider, Http},
+    types::{Address, H256},
+    contract::{abigen},
+    middleware::Middleware,
+};
+use std::sync::Arc;
+use crate::config::{get_safe_tx_pool_address, get_network_name, DEFAULT_MAINNET_RPC};
+
+// Generate contract bindings using the exact ABI from the contract at commit 3658aca34ee38cba8e5bb9ed90927c270df8584d
+abigen!(
+    SafeTxPool,
+    r#"[
+        function getTxDetails(bytes32 txHash) external view returns (address safe, address to, uint256 value, bytes data, uint8 operation, address proposer, uint256 nonce)
+        function getSignatures(bytes32 txHash) external view returns (bytes[] memory)
+        function getPendingTxHashes(address safe) external view returns (bytes32[] memory)
+        function hasSignedTx(bytes32 txHash, address signer) external view returns (bool)
+    ]"#
+);
+
+// Define a struct to hold transaction data in a more user-friendly format
+#[derive(serde::Serialize)]
+struct TransactionData {
+    hash: String,
+    safe: String,
+    to: String,
+    value: String,
+    data: String,
+    operation: u8,
+    proposer: String,
+    nonce: String,
+    signatures: Vec<String>,
+}
+
+pub async fn execute(safe: String, rpc: Option<String>, hash: Option<String>, tx_pool: Option<String>) -> Result<()> {
+    // Validate safe address
+    let safe_address = Address::from_str(&safe)
+        .context("Invalid Safe wallet address format")?;
+
+    // Use the provided RPC or the default mainnet RPC
+    let rpc_url = rpc.unwrap_or_else(|| {
+        println!("No RPC URL provided, using default Ethereum mainnet RPC");
+        DEFAULT_MAINNET_RPC.to_string()
+    });
+
+    // Connect to provider
+    let provider = Provider::<Http>::try_from(rpc_url.clone())
+        .context("Failed to connect to RPC provider")?;
+    
+    let provider = Arc::new(provider);
+
+    // Get chain ID first to identify the network
+    let chain_id = provider.get_chainid().await
+        .context("Failed to get chain ID from network")?;
+    
+    let network_id = chain_id.as_u64();
+    let network_name = get_network_name(network_id);
+    
+    println!("Connected to {} (Chain ID: {})", network_name, network_id);
+
+    // Check if safe exists by attempting to get its code
+    let code = provider.get_code(safe_address, None).await
+        .context("Failed to query the network")?;
+    
+    if code.is_empty() {
+        bail!("Safe wallet address not found on {}", network_name);
+    }
+
+    // Determine transaction pool address
+    let tx_pool_address = if let Some(custom_address) = tx_pool {
+        // User provided a custom address
+        println!("Using custom Safe transaction pool address: {}", custom_address);
+        Address::from_str(&custom_address)
+            .context("Invalid custom Safe transaction pool address")?
+    } else {
+        // Get the network-specific transaction pool address
+        let tx_pool_address_str = get_safe_tx_pool_address(network_id);
+        println!("Using Safe transaction pool at {} for {}", tx_pool_address_str, network_name);
+        
+        // Parse the address
+        Address::from_str(tx_pool_address_str)
+            .context("Invalid Safe transaction pool address")?
+    };
+    
+    // Verify that the transaction pool contract exists
+    let contract_code = provider.get_code(tx_pool_address, None).await
+        .context("Failed to query the network for transaction pool contract")?;
+    
+    if contract_code.is_empty() {
+        bail!("Transaction pool contract not found at {}. Please verify the contract address for {} is correct.", 
+              tx_pool_address, network_name);
+    }
+    
+    // Create contract instance
+    let contract = SafeTxPool::new(tx_pool_address, provider.clone());
+    
+    if let Some(tx_hash) = hash {
+        // Convert hash string to H256
+        let hash = H256::from_str(&tx_hash)
+            .context("Invalid transaction hash format")?;
+        
+        println!("Fetching transaction with hash {} for Safe {}", tx_hash, safe);
+        
+        // Fetch the transaction details from the Safe transaction pool
+        let tx_details = match contract.get_tx_details(hash.into()).call().await {
+            Ok(details) => details,
+            Err(e) => {
+                bail!("Failed to fetch transaction details: {}. This could be because the transaction does not exist or the contract interface is incorrect.", e);
+            }
+        };
+
+        // Check if the transaction exists (proposer address will be zero if not)
+        if tx_details.5 == Address::zero() {
+            bail!("Transaction not found or has already been executed");
+        }
+        
+        // Fetch the signatures for this transaction
+        let signatures = match contract.get_signatures(hash.into()).call().await {
+            Ok(sigs) => sigs,
+            Err(e) => {
+                bail!("Failed to fetch transaction signatures: {}. This could be because the transaction does not exist or the contract interface is incorrect.", e);
+            }
+        };
+        
+        // Convert signatures to hex strings
+        let signature_strings: Vec<String> = signatures.into_iter()
+            .map(|sig| format!("0x{}", hex::encode(sig.to_vec())))
+            .collect();
+        
+        // Create a structured representation of the transaction
+        let tx_data = TransactionData {
+            hash: format!("0x{}", hex::encode(hash.as_bytes())),
+            safe: format!("0x{:x}", tx_details.0),
+            to: format!("0x{:x}", tx_details.1),
+            value: tx_details.2.to_string(),
+            data: format!("0x{}", hex::encode(tx_details.3.to_vec())),
+            operation: tx_details.4 as u8,
+            proposer: format!("0x{:x}", tx_details.5),
+            nonce: tx_details.6.to_string(),
+            signatures: signature_strings,
+        };
+        
+        // Convert transaction to JSON and print it
+        println!("{}", serde_json::to_string_pretty(&tx_data).unwrap());
+    } else {
+        println!("Fetching all pending transactions for Safe {}", safe);
+        
+        // Get all pending transaction hashes for the Safe
+        // The contract doesn't paginate, just returns all hashes at once
+        let all_tx_hashes_raw = match contract.get_pending_tx_hashes(safe_address).call().await {
+            Ok(hashes) => hashes,
+            Err(e) => {
+                bail!("Failed to fetch pending transaction hashes: {}. This could be because the contract interface is incorrect or the contract does not support this function.", e);
+            }
+        };
+        
+        // Convert raw bytes32 array to H256 vector
+        let all_tx_hashes: Vec<H256> = all_tx_hashes_raw.into_iter()
+            .map(|h| H256::from_slice(&h))
+            .collect();
+        
+        if all_tx_hashes.is_empty() {
+            println!("No pending transactions found for Safe {}", safe);
+            return Ok(());
+        }
+        
+        println!("Found {} pending transactions", all_tx_hashes.len());
+        
+        // Fetch details for each transaction hash
+        let mut transactions = Vec::new();
+        for tx_hash in all_tx_hashes {
+            // Fetch transaction details
+            match contract.get_tx_details(tx_hash.into()).call().await {
+                Ok(tx_details) => {
+                    // Fetch signatures
+                    let signatures = match contract.get_signatures(tx_hash.into()).call().await {
+                        Ok(sigs) => sigs.into_iter()
+                            .map(|sig| format!("0x{}", hex::encode(sig.to_vec())))
+                            .collect(),
+                        Err(_) => vec![]
+                    };
+                    
+                    // Create transaction data object
+                    let tx_data = TransactionData {
+                        hash: format!("0x{}", hex::encode(tx_hash.as_bytes())),
+                        safe: format!("0x{:x}", tx_details.0),
+                        to: format!("0x{:x}", tx_details.1),
+                        value: tx_details.2.to_string(),
+                        data: format!("0x{}", hex::encode(tx_details.3.to_vec())),
+                        operation: tx_details.4 as u8,
+                        proposer: format!("0x{:x}", tx_details.5),
+                        nonce: tx_details.6.to_string(),
+                        signatures,
+                    };
+                    
+                    transactions.push(tx_data);
+                },
+                Err(e) => {
+                    println!("Warning: Failed to fetch details for transaction {}: {}", tx_hash, e);
+                }
+            }
+        }
+        
+        // Sort transactions by nonce for better readability
+        transactions.sort_by(|a, b| {
+            let a_nonce = a.nonce.parse::<u64>().unwrap_or(0);
+            let b_nonce = b.nonce.parse::<u64>().unwrap_or(0);
+            a_nonce.cmp(&b_nonce)
+        });
+        
+        // Convert the list to JSON and print it
+        println!("{}", serde_json::to_string_pretty(&transactions).unwrap());
+    }
+
+    Ok(())
+} 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,56 @@
+// Configuration constants for the application
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+
+// Network IDs
+pub const MAINNET: u64 = 1;
+pub const GOERLI: u64 = 5;
+pub const SEPOLIA: u64 = 11155111;
+pub const POLYGON: u64 = 137;
+pub const ARBITRUM: u64 = 42161;
+pub const OPTIMISM: u64 = 10;
+pub const BASE: u64 = 8453;
+pub const GNOSIS: u64 = 100;
+
+// Default RPC endpoint for Ethereum mainnet
+// Note: In production, you should use your own API key
+pub const DEFAULT_MAINNET_RPC: &str = "https://eth-mainnet.g.alchemy.com/v2/demo";
+
+lazy_static! {
+    // Map of network IDs to Safe transaction pool addresses
+    pub static ref SAFE_TX_POOL_ADDRESSES: HashMap<u64, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert(MAINNET, "0x6b8e1f0D2c34A0AeaD9A25B6966f7C0CAD653E5c");
+        m.insert(GOERLI, "0x3A4fA54b8AaB5E2E2DBD0a41f41f629e4e71e2E7");
+        m.insert(SEPOLIA, "0xa2ad21dc93B362570D0159b9E3A2fE5D8ecA0424");
+        m.insert(POLYGON, "0xA3B9Ff95a78e04845a82ee5F75595E7bDaB8723D");
+        m.insert(ARBITRUM, "0x7c4A2Db70E5f39BA5Db11B8A942f02A8D3B3aA1B");
+        m.insert(OPTIMISM, "0x6E4d941A6fAD76B3d26E0c5447B4f5A7EfcA8ab8");
+        m.insert(BASE, "0x2d340e22C5A33c1Ea01DAC41E331b7FE4c033C3b");
+        m.insert(GNOSIS, "0x8d0C7BC9c4c588534dC1BF96d3ee9A4bCcBf28C7");
+        m
+    };
+}
+
+// Default fallback address if network is not recognized
+pub const DEFAULT_SAFE_TX_POOL_ADDRESS: &str = "0x6b8e1f0D2c34A0AeaD9A25B6966f7C0CAD653E5c";
+
+// Get network name from chain ID for display purposes
+pub fn get_network_name(chain_id: u64) -> &'static str {
+    match chain_id {
+        MAINNET => "Ethereum Mainnet",
+        GOERLI => "Goerli Testnet",
+        SEPOLIA => "Sepolia Testnet",
+        POLYGON => "Polygon",
+        ARBITRUM => "Arbitrum",
+        OPTIMISM => "Optimism",
+        BASE => "Base",
+        GNOSIS => "Gnosis Chain",
+        _ => "Unknown Network"
+    }
+}
+
+// Get Safe transaction pool address for a network
+pub fn get_safe_tx_pool_address(network_id: u64) -> &'static str {
+    SAFE_TX_POOL_ADDRESSES.get(&network_id).unwrap_or(&DEFAULT_SAFE_TX_POOL_ADDRESS)
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,54 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use anyhow::Result;
 
-/// A CLI tool template
+mod commands;
+mod config;
+
+/// A CLI tool for Ethereum Safe operations
 #[derive(Parser)]
 #[command(
     name = "vito",
     author, 
     version, 
-    about = "A powerful CLI tool for managing your projects", 
-    long_about = "A feature-rich command-line interface tool designed to help you manage your projects more efficiently."
+    about = "A powerful CLI tool for managing Safe wallet transactions", 
+    long_about = "A feature-rich command-line interface tool designed to help you interact with Ethereum Safe wallets."
 )]
 struct Cli {
-    // Add your command line arguments here
+    #[command(subcommand)]
+    command: Commands,
 }
 
-fn main() -> Result<()> {
-    let _cli = Cli::parse();
+#[derive(Subcommand)]
+enum Commands {
+    /// Fetch transaction data from Safe transaction pool
+    Tx {
+        /// Ethereum Safe wallet address (0x...)
+        #[arg(short, long)]
+        safe: String,
+
+        /// Provider RPC URL (http:// or https://) - Optional, defaults to Ethereum mainnet
+        #[arg(short, long)]
+        rpc: Option<String>,
+
+        /// Transaction hash (0x...) - Optional
+        #[arg(short = 't', long)]
+        hash: Option<String>,
+
+        /// Custom Safe transaction pool address (0x...) - Optional
+        #[arg(long)]
+        tx_pool: Option<String>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    
+    match cli.command {
+        Commands::Tx { safe, rpc, hash, tx_pool } => {
+            commands::tx::execute(safe, rpc, hash, tx_pool).await?;
+        }
+    }
+    
     Ok(())
 }


### PR DESCRIPTION
This PR adds a new `tx` command to the Vito CLI that interacts with Safe Transaction Pool contracts.

## Features
- Query transaction data from Safe Transaction Pool contracts
- Fetch specific transaction by hash with `--hash/-t` option
- List all pending transactions for a Safe wallet
- Auto-detect network and use appropriate contract address
- Support custom transaction pool address with `--tx-pool`
- Format results as structured JSON
- Provide helpful error messages

## Usage Examples
```bash
# Get all pending transactions for a Safe wallet
vito tx --safe 0x7a3d07cABd656aEc614831B6eFAbd014697c9E19 --rpc https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY

# Get a specific transaction by hash
vito tx --safe 0x7a3d07cABd656aEc614831B6eFAbd014697c9E19 -t 0x24c371247a4d30ff0dd00a675f0e1630fa044498ae529043d39af43ea4e7a4a8

# Use default mainnet RPC
vito tx --safe 0x7a3d07cABd656aEc614831B6eFAbd014697c9E19
```